### PR TITLE
Configure direct launch to ai catalog

### DIFF
--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -1,18 +1,13 @@
-import { Cards } from '@/components/cards';
-import styles from '@/styles/app.module.css';
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
 
 export default function Home() {
-  return (
-    <main className={styles.main}>
-      <div className={styles.description}> </div>
+  const router = useRouter();
 
-      <div className={styles.center}>
-        <div className={styles.emoji}>😏</div>
-      </div>
+  useEffect(() => {
+    router.push('/ai-catalog');
+  }, [router]);
 
-      <div className={styles.grid}>
-        <Cards />
-      </div>
-    </main>
-  );
+  // Show nothing while redirecting
+  return null;
 }


### PR DESCRIPTION
Remove the splash page and redirect the homepage to `/ai-catalog`.